### PR TITLE
Select manga on search

### DIFF
--- a/lib/dmanga/site_parser_base.rb
+++ b/lib/dmanga/site_parser_base.rb
@@ -4,6 +4,8 @@ require 'ruby-progressbar'
 require 'open-uri'
 require 'addressable/uri'
 
+# todo: if downloading returns an error, skip to next chapter
+
 module DManga
   class SiteParserBase
     USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:76.0) Gecko/20100101 Firefox/76.0"
@@ -52,18 +54,21 @@ module DManga
     def select_manga(mangas)
       puts # just a new line for better output
       unless mangas.empty?
-        mangas.each do |manga|
-          DManga::display_prompt("Você quer baixar #{manga[1]} [s/n]? ")
-          res = $stdin.gets.chomp
-          if res == 's'
-            @manga_url = manga[0]
-            @manga_name = manga[1]
-            break
-          elsif res != 'n'
-            DManga::display_warn("\tOpção invalida")
-            DManga::display_feedback("\tSaindo")
-            exit(true)
+        mangas.each_with_index do |manga, index|
+          DManga::display_feedback "(#{index + 1}) #{manga[1]}"
+        end
+        DManga::display_prompt "Selecionar manga: "
+        res = $stdin.gets.chomp
+        if res =~ /^\d+$/
+          res = res.to_i
+          if res > 0 && res <= mangas.length
+            @manga_name = mangas[res - 1][1]
+            @manga_url = mangas[res - 1][0]
+          else
+            DManga::display_warn("ERRO: Opção inválida")
           end
+        else
+          DManga::display_warn("ERRO: Opção inválida")
         end
       else
         raise MangaNotFoundError, "manga não encontrado"

--- a/test/site_parser_base_test.rb
+++ b/test/site_parser_base_test.rb
@@ -131,11 +131,11 @@ class TestSiteParserBase < Minitest::Test
          "Punch!"],
          ["https://mangahost.net/manga/short-program-girls-type",
           "Short Program - Girl's Type"]]
-        $stdin = StringIO.new("n\nn\ns\n") #simulate user input
+        $stdin = StringIO.new("2") #simulate user input
         @site_parser.select_manga(mangas)
         $stdin = STDIN
-        assert_equal @site_parser.manga_url, mangas[2][0]
-        assert_equal @site_parser.manga_name, mangas[2][1]
+        assert_equal @site_parser.manga_url, mangas[1][0]
+        assert_equal @site_parser.manga_name, mangas[1][1]
     end
 
     # test "test select manga when manga was not found" do
@@ -148,7 +148,7 @@ class TestSiteParserBase < Minitest::Test
           "One Punch-Man (One)"],
         ["https://mangahost.net/manga/punch",
          "Punch!"]]
-        $stdin = StringIO.new("n\nn\nn\nn\n") #simulate user input
+        $stdin = StringIO.new("6") #simulate user input
         assert_raises(DManga::MangaNotFoundError) {@site_parser.select_manga(mangas)}
         $stdin = STDIN
     end


### PR DESCRIPTION
Alteração feita ao pesquisar um anime, onde em vez de ter que selecionar por s/n, alterei para listar (como os capitulos) e selecionar o manga desejado. 
Lamento se tiver algum erro no código, não tenho experiência nenhuma com Ruby. Qualquer coisa pode me comunicar ou editar diretamente se preferir.
