### PR TITLE
fixed download for files with .webp and afiv terminations

### DIFF
--- a/lib/dmanga/mangahost_parser.rb
+++ b/lib/dmanga/mangahost_parser.rb
@@ -74,7 +74,7 @@ module DManga
             # some images urls are incorrect and need to be corrected. For exemple:
             # img.mangahost.net/br/images/img.png.webp => img.mangahost.net/br/mangas_files/img.png
             img.sub!(/images/, "mangas_files")
-            img.sub!(/\.webp/, "")
+            img.sub!(/\.png.webp/, ".png")
 
             #correct créditos img problem
             correct_image_uri(img)

--- a/lib/dmanga/site_parser_base.rb
+++ b/lib/dmanga/site_parser_base.rb
@@ -145,8 +145,10 @@ module DManga
     # download images to path relative to Downloads directory
     def imgs_download(chp_path, imgs_urls)
       imgs_urls.each do |url|
-        original_filename =  url.slice(/(?u)(\w|[_-])+\.(png|jpg)/i)
-
+        original_filename =  url.slice(/(?u)(\w|[_-])+\.(png|jpg|webp|afiv)/i)
+        DManga::display_feedback "nome:'#{original_filename}'" 
+        DManga::display_feedback "url:'#{url}'" 
+        DManga::display_feedback "ch_path:'#{chp_path}'"
         img_path = [@options.download_dir,
                     chp_path,
                     original_filename].join(File::SEPARATOR)


### PR DESCRIPTION
Was having problems downloading mangas such as God of Martial Arts due to Webp ending, fixed and added .afiv support as well